### PR TITLE
brain mode

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -22,6 +22,8 @@
 #include <cstring>   // For std::memset
 #include <iostream>
 #include <sstream>
+#include <chrono>
+#include <thread>
 
 #include "evaluate.h"
 #include "misc.h"
@@ -212,8 +214,10 @@ void MainThread::search() {
   // GUI sends a "stop" or "ponderhit" command. We therefore simply wait here
   // until the GUI sends one of those commands.
 
-  while (!Threads.stop && (ponder || Limits.infinite))
-  {} // Busy wait for a stop or a ponder reset
+   while (!Threads.stop && (ponder || Limits.infinite || brain))
+  {	  
+  if (brain) { std::this_thread::sleep_for(std::chrono::milliseconds(500));  break; } 
+  }
 
   // Stop the threads if not already stopped (also raise the stop if
   // "ponderhit" just reset Threads.ponder).
@@ -1827,7 +1831,7 @@ void MainThread::check_time() {
   }
 
   // We should not stop pondering until told so by the GUI
-  if (ponder)
+if (ponder || brain)
       return;
 
   if (   (Limits.use_time_management() && (elapsed > Time.maximum() - 10 || stopOnPonderhit))

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -171,13 +171,14 @@ void ThreadPool::clear() {
 /// returns immediately. Main thread will wake up other threads and start the search.
 
 void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
-                                const Search::LimitsType& limits, bool ponderMode) {
+                                const Search::LimitsType& limits, bool ponderMode,  bool brainmode) {
 
   main()->wait_for_search_finished();
 
   main()->stopOnPonderhit = stop = false;
   increaseDepth = true;
   main()->ponder = ponderMode;
+  main()->brain = brainmode;
   Search::Limits = limits;
   Search::RootMoves rootMoves;
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -95,6 +95,7 @@ struct MainThread : public Thread {
   int callsCnt;
   bool stopOnPonderhit;
   std::atomic_bool ponder;
+  std::atomic_bool brain;
 };
 
 
@@ -104,7 +105,7 @@ struct MainThread : public Thread {
 
 struct ThreadPool : public std::vector<Thread*> {
 
-  void start_thinking(Position&, StateListPtr&, const Search::LimitsType&, bool = false);
+  void start_thinking(Position&, StateListPtr&, const Search::LimitsType&, bool = false, bool = false);
   void clear();
   void set(size_t);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -126,6 +126,7 @@ namespace {
     Search::LimitsType limits;
     string token;
     bool ponderMode = false;
+    bool brainMode = false;
 
     limits.startTime = now(); // As early as possible!
 
@@ -146,8 +147,9 @@ namespace {
         else if (token == "perft")     is >> limits.perft;
         else if (token == "infinite")  limits.infinite = 1;
         else if (token == "ponder")    ponderMode = true;
+        else if (token == "brain")     brainMode = true;
 
-    Threads.start_thinking(pos, states, limits, ponderMode);
+    Threads.start_thinking(pos, states, limits, ponderMode, brainMode);
   }
 
 


### PR DESCRIPTION
**In engine tournaments, if two engines are playing against each other, using permanent brain slows down the side that is computing the next move (because it has to share resources with the other side's permanent brain)**

http://help.chessbase.com/Fritz/15/Eng/index.html?000028.htm

Brain Mode is A Feature That Make Stronger Chess Engine , The Idea of Brain Mode Is Base Of Chess Base Authors , They Found A Lot Of Process May Cause Reduce CPU Performance & Cause Calculate Wrong Best Move

This method is currently used by Chess Base GUI Fritz , Komodo , . . .