### PR TITLE
Apply include-what-you-use suggestions

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -18,9 +18,9 @@
 
 #include "benchmark.h"
 
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <istream>
 #include <vector>
 
 #include "position.h"

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <bitset>
+#include <initializer_list>
 
 #include "misc.h"
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -19,6 +19,11 @@
 #ifndef BITBOARD_H_INCLUDED
 #define BITBOARD_H_INCLUDED
 
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
 #include <string>
 
 #include "types.h"

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -20,21 +20,20 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdlib>
 #include <fstream>
 #include <iomanip>
-#include <sstream>
 #include <iostream>
-#include <streambuf>
+#include <sstream>
 #include <vector>
 
-#include "position.h"
-#include "bitboard.h"
-#include "misc.h"
-#include "thread.h"
-#include "timeman.h"
-#include "uci.h"
 #include "incbin/incbin.h"
+#include "misc.h"
 #include "nnue/evaluate_nnue.h"
+#include "position.h"
+#include "thread.h"
+#include "types.h"
+#include "uci.h"
 
 // Macro to embed the default efficiently updatable neural network (NNUE) file
 // data in the engine binary (using incbin.h, by Dale Weiler).

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -20,13 +20,11 @@
 #define EVALUATE_H_INCLUDED
 
 #include <string>
-#include <optional>
-
-#include "types.h"
 
 namespace Stockfish {
 
 class Position;
+enum Value : int;
 
 namespace Eval {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,14 +16,17 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <cstddef>
 #include <iostream>
 
 #include "bitboard.h"
+#include "evaluate.h"
+#include "misc.h"
 #include "position.h"
 #include "search.h"
-#include "syzygy/tbprobe.h"
 #include "thread.h"
-#include "tt.h"
+#include "tune.h"
+#include "types.h"
 #include "uci.h"
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -16,6 +16,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "misc.h"
+
 #ifdef _WIN32
 #if _WIN32_WINNT < 0x0601
 #undef  _WIN32_WINNT
@@ -44,17 +46,19 @@ using fun8_t = bool(*)(HANDLE, BOOL, PTOKEN_PRIVILEGES, DWORD, PTOKEN_PRIVILEGES
 }
 #endif
 
+#include <atomic>
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <mutex>
 #include <sstream>
 #include <string_view>
-#include <vector>
+
+#include "types.h"
 
 #if defined(__linux__) && !defined(__ANDROID__)
-#include <stdlib.h>
 #include <sys/mman.h>
 #endif
 
@@ -62,9 +66,6 @@ using fun8_t = bool(*)(HANDLE, BOOL, PTOKEN_PRIVILEGES, DWORD, PTOKEN_PRIVILEGES
 #define POSIXALIGNEDALLOC
 #include <stdlib.h>
 #endif
-
-#include "misc.h"
-#include "thread.h"
 
 using namespace std;
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -21,12 +21,10 @@
 
 #include <cassert>
 #include <chrono>
-#include <ostream>
-#include <string>
-#include <vector>
+#include <cstddef>
 #include <cstdint>
-
-#include "types.h"
+#include <iosfwd>
+#include <string>
 
 #define stringify2(x) #x
 #define stringify(x) stringify2(x)

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -19,7 +19,9 @@
 #include "movegen.h"
 
 #include <cassert>
+#include <initializer_list>
 
+#include "bitboard.h"
 #include "position.h"
 
 namespace Stockfish {

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -20,6 +20,7 @@
 #define MOVEGEN_H_INCLUDED
 
 #include <algorithm>
+#include <cstddef>
 
 #include "types.h"
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -18,7 +18,10 @@
 
 #include "movepick.h"
 
+#include <algorithm>
 #include <cassert>
+#include <iterator>
+#include <utility>
 
 #include "bitboard.h"
 #include "position.h"

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -20,14 +20,17 @@
 #define MOVEPICK_H_INCLUDED
 
 #include <array>
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
 #include <limits>
 #include <type_traits>
 
 #include "movegen.h"
-#include "position.h"
 #include "types.h"
 
 namespace Stockfish {
+class Position;
 
 /// StatsEntry stores the stat table value. It is usually a number but could
 /// be a move or even a nested history. We use a class instead of naked value

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -20,19 +20,22 @@
 
 #include "evaluate_nnue.h"
 
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <set>
 #include <sstream>
 #include <string_view>
 
 #include "../evaluate.h"
+#include "../misc.h"
 #include "../position.h"
-#include "../uci.h"
 #include "../types.h"
-#include "../position.h"
-
+#include "../uci.h"
+#include "nnue_accumulator.h"
+#include "nnue_common.h"
 
 namespace Stockfish::Eval::NNUE {
 

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -21,10 +21,20 @@
 #ifndef NNUE_EVALUATE_NNUE_H_INCLUDED
 #define NNUE_EVALUATE_NNUE_H_INCLUDED
 
-#include "nnue_feature_transformer.h"
-#include "../position.h"
-
+#include <cstdint>
+#include <iosfwd>
 #include <memory>
+#include <optional>
+#include <string>
+
+#include "../misc.h"
+#include "nnue_architecture.h"
+#include "nnue_feature_transformer.h"
+
+namespace Stockfish {
+  class Position;
+  enum Value : int;
+}
 
 namespace Stockfish::Eval::NNUE {
 

--- a/src/nnue/features/half_ka_v2_hm.cpp
+++ b/src/nnue/features/half_ka_v2_hm.cpp
@@ -20,7 +20,10 @@
 
 #include "half_ka_v2_hm.h"
 
+#include "../../bitboard.h"
 #include "../../position.h"
+#include "../../types.h"
+#include "../nnue_common.h"
 
 namespace Stockfish::Eval::NNUE::Features {
 

--- a/src/nnue/features/half_ka_v2_hm.h
+++ b/src/nnue/features/half_ka_v2_hm.h
@@ -21,10 +21,11 @@
 #ifndef NNUE_FEATURES_HALF_KA_V2_HM_H_INCLUDED
 #define NNUE_FEATURES_HALF_KA_V2_HM_H_INCLUDED
 
-#include "../nnue_common.h"
+#include <cstdint>
 
-#include "../../evaluate.h"
 #include "../../misc.h"
+#include "../../types.h"
+#include "../nnue_common.h"
 
 namespace Stockfish {
   struct StateInfo;

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -21,12 +21,10 @@
 #ifndef NNUE_LAYERS_AFFINE_TRANSFORM_H_INCLUDED
 #define NNUE_LAYERS_AFFINE_TRANSFORM_H_INCLUDED
 
+#include <cstdint>
 #include <iostream>
-#include <algorithm>
-#include <type_traits>
 
 #include "../nnue_common.h"
-
 #include "simd.h"
 
 /*

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -21,17 +21,15 @@
 #ifndef NNUE_LAYERS_AFFINE_TRANSFORM_SPARSE_INPUT_H_INCLUDED
 #define NNUE_LAYERS_AFFINE_TRANSFORM_SPARSE_INPUT_H_INCLUDED
 
-#include <iostream>
 #include <algorithm>
 #include <array>
-#include <type_traits>
-
-#include "../nnue_common.h"
-
-#include "affine_transform.h"
-#include "simd.h"
+#include <cstdint>
+#include <iostream>
 
 #include "../../bitboard.h"
+#include "../nnue_common.h"
+#include "affine_transform.h"
+#include "simd.h"
 
 /*
   This file contains the definition for a fully connected layer (aka affine transform) with block sparse input.

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -21,6 +21,10 @@
 #ifndef NNUE_LAYERS_CLIPPED_RELU_H_INCLUDED
 #define NNUE_LAYERS_CLIPPED_RELU_H_INCLUDED
 
+#include <algorithm>
+#include <cstdint>
+#include <iosfwd>
+
 #include "../nnue_common.h"
 
 namespace Stockfish::Eval::NNUE::Layers {

--- a/src/nnue/layers/sqr_clipped_relu.h
+++ b/src/nnue/layers/sqr_clipped_relu.h
@@ -21,6 +21,10 @@
 #ifndef NNUE_LAYERS_SQR_CLIPPED_RELU_H_INCLUDED
 #define NNUE_LAYERS_SQR_CLIPPED_RELU_H_INCLUDED
 
+#include <algorithm>
+#include <cstdint>
+#include <iosfwd>
+
 #include "../nnue_common.h"
 
 namespace Stockfish::Eval::NNUE::Layers {

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -21,7 +21,10 @@
 #ifndef NNUE_ACCUMULATOR_H_INCLUDED
 #define NNUE_ACCUMULATOR_H_INCLUDED
 
+#include <cstdint>
+
 #include "nnue_architecture.h"
+#include "nnue_common.h"
 
 namespace Stockfish::Eval::NNUE {
 

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -21,18 +21,16 @@
 #ifndef NNUE_ARCHITECTURE_H_INCLUDED
 #define NNUE_ARCHITECTURE_H_INCLUDED
 
-#include <memory>
-
-#include "nnue_common.h"
+#include <cstdint>
+#include <cstring>
+#include <iosfwd>
 
 #include "features/half_ka_v2_hm.h"
-
-#include "layers/affine_transform_sparse_input.h"
 #include "layers/affine_transform.h"
+#include "layers/affine_transform_sparse_input.h"
 #include "layers/clipped_relu.h"
 #include "layers/sqr_clipped_relu.h"
-
-#include "../misc.h"
+#include "nnue_common.h"
 
 namespace Stockfish::Eval::NNUE {
 

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -21,10 +21,14 @@
 #ifndef NNUE_COMMON_H_INCLUDED
 #define NNUE_COMMON_H_INCLUDED
 
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <type_traits>
 
-#include "../misc.h"  // for IsLittleEndian
+#include "../misc.h"
 
 #if defined(USE_AVX2)
 #include <immintrin.h>

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -21,13 +21,18 @@
 #ifndef NNUE_FEATURE_TRANSFORMER_H_INCLUDED
 #define NNUE_FEATURE_TRANSFORMER_H_INCLUDED
 
-#include <cstring> // std::memset()
-#include <utility> // std::pair
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <iosfwd>
+#include <utility>
 
-#include "nnue_common.h"
-
-#include "nnue_architecture.h"
 #include "../position.h"
+#include "../types.h"
+#include "nnue_accumulator.h"
+#include "nnue_architecture.h"
+#include "nnue_common.h"
 
 namespace Stockfish::Eval::NNUE {
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -19,20 +19,26 @@
 #include "position.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
-#include <cstddef> // For offsetof()
-#include <cstring> // For std::memset, std::memcmp
+#include <cctype>
+#include <cstddef>
+#include <cstring>
+#include <initializer_list>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 #include <string_view>
+#include <utility>
 
 #include "bitboard.h"
 #include "misc.h"
 #include "movegen.h"
+#include "nnue/nnue_common.h"
+#include "syzygy/tbprobe.h"
 #include "thread.h"
 #include "tt.h"
 #include "uci.h"
-#include "syzygy/tbprobe.h"
 
 using std::string;
 

--- a/src/position.h
+++ b/src/position.h
@@ -21,14 +21,13 @@
 
 #include <cassert>
 #include <deque>
-#include <memory> // For std::unique_ptr
+#include <iosfwd>
+#include <memory>
 #include <string>
 
 #include "bitboard.h"
-#include "evaluate.h"
-#include "types.h"
-
 #include "nnue/nnue_accumulator.h"
+#include "types.h"
 
 namespace Stockfish {
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -19,23 +19,31 @@
 #include "search.h"
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <cassert>
 #include <cmath>
-#include <cstring>   // For std::memset
+#include <cstdlib>
+#include <cstring>
+#include <initializer_list>
 #include <iostream>
 #include <sstream>
+#include <string>
+#include <utility>
 
+#include "bitboard.h"
 #include "evaluate.h"
 #include "misc.h"
 #include "movegen.h"
 #include "movepick.h"
+#include "nnue/evaluate_nnue.h"
+#include "nnue/nnue_common.h"
 #include "position.h"
+#include "syzygy/tbprobe.h"
 #include "thread.h"
 #include "timeman.h"
 #include "tt.h"
 #include "uci.h"
-#include "syzygy/tbprobe.h"
-#include "nnue/evaluate_nnue.h"
 
 namespace Stockfish {
 

--- a/src/search.h
+++ b/src/search.h
@@ -19,6 +19,7 @@
 #ifndef SEARCH_H_INCLUDED
 #define SEARCH_H_INCLUDED
 
+#include <cstdint>
 #include <vector>
 
 #include "misc.h"

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -18,20 +18,26 @@
 
 #include "tbprobe.h"
 
+#include <sys/stat.h>
 #include <algorithm>
 #include <atomic>
+#include <cassert>
 #include <cstdint>
-#include <cstring>   // For std::memset and std::memcpy
+#include <cstdlib>
+#include <cstring>
 #include <deque>
 #include <fstream>
+#include <initializer_list>
 #include <iostream>
-#include <list>
 #include <mutex>
 #include <sstream>
 #include <string_view>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "../bitboard.h"
+#include "../misc.h"
 #include "../movegen.h"
 #include "../position.h"
 #include "../search.h"
@@ -40,9 +46,8 @@
 
 #ifndef _WIN32
 #include <fcntl.h>
-#include <unistd.h>
 #include <sys/mman.h>
-#include <sys/stat.h>
+#include <unistd.h>
 #else
 #define WIN32_LEAN_AND_MEAN
 #ifndef NOMINMAX

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -19,8 +19,13 @@
 #ifndef TBPROBE_H
 #define TBPROBE_H
 
+#include <string>
+
 #include "../search.h"
-#include "../position.h"
+
+namespace Stockfish {
+class Position;
+}
 
 namespace Stockfish::Tablebases {
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -18,16 +18,21 @@
 
 #include "thread.h"
 
+#include <algorithm>
 #include <cassert>
-#include <algorithm> // For std::count
+#include <cstdlib>
+#include <deque>
+#include <initializer_list>
+#include <map>
+#include <memory>
+#include <utility>
 
+#include "misc.h"
 #include "movegen.h"
 #include "search.h"
-
-#include "uci.h"
 #include "syzygy/tbprobe.h"
 #include "tt.h"
-#include "position.h"
+#include "uci.h"
 
 namespace Stockfish {
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -21,14 +21,16 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstddef>
+#include <cstdint>
 #include <mutex>
-#include <thread>
 #include <vector>
 
 #include "movepick.h"
 #include "position.h"
 #include "search.h"
 #include "thread_win32_osx.h"
+#include "types.h"
 
 namespace Stockfish {
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -19,7 +19,6 @@
 #include "timeman.h"
 
 #include <algorithm>
-#include <cfloat>
 #include <cmath>
 
 #include "search.h"

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -19,9 +19,12 @@
 #ifndef TIMEMAN_H_INCLUDED
 #define TIMEMAN_H_INCLUDED
 
+#include <cstdint>
+
 #include "misc.h"
 #include "search.h"
 #include "thread.h"
+#include "types.h"
 
 namespace Stockfish {
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -18,11 +18,13 @@
 
 #include "tt.h"
 
-#include <cstring>   // For std::memset
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <thread>
+#include <vector>
 
-#include "bitboard.h"
 #include "misc.h"
 #include "thread.h"
 #include "uci.h"

--- a/src/tt.h
+++ b/src/tt.h
@@ -19,6 +19,9 @@
 #ifndef TT_H_INCLUDED
 #define TT_H_INCLUDED
 
+#include <cstddef>
+#include <cstdint>
+
 #include "misc.h"
 #include "types.h"
 

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -16,13 +16,19 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "tune.h"
+
 #include <algorithm>
 #include <iostream>
+#include <map>
 #include <sstream>
+#include <string>
 
-#include "types.h"
-#include "misc.h"
 #include "uci.h"
+
+namespace Stockfish {
+enum Value : int;
+}
 
 using std::string;
 
@@ -108,7 +114,6 @@ template<> void Tune::Entry<Tune::PostUpdate>::read_option() { value(); }
 //
 // Then paste the output below, as the function body
 
-#include <cmath>
 
 namespace Stockfish {
 

--- a/src/tune.h
+++ b/src/tune.h
@@ -19,12 +19,15 @@
 #ifndef TUNE_H_INCLUDED
 #define TUNE_H_INCLUDED
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace Stockfish {
+enum Value : int;
 
 using Range = std::pair<int, int>; // Option's min-max values
 using RangeFun = Range (int);

--- a/src/types.h
+++ b/src/types.h
@@ -37,10 +37,7 @@
 ///               | only in 64-bit mode and requires hardware with pext support.
 
 #include <cassert>
-#include <cctype>
 #include <cstdint>
-#include <cstdlib>
-#include <algorithm>
 
 #if defined(_MSC_VER)
 // Disable some silly and noisy warning from MSVC compiler

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -18,22 +18,28 @@
 
 #include "uci.h"
 
+#include <algorithm>
 #include <cassert>
+#include <cctype>
 #include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <deque>
 #include <iostream>
+#include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "benchmark.h"
 #include "evaluate.h"
+#include "misc.h"
 #include "movegen.h"
+#include "nnue/evaluate_nnue.h"
 #include "position.h"
 #include "search.h"
 #include "thread.h"
-#include "timeman.h"
-#include "tt.h"
-#include "syzygy/tbprobe.h"
-#include "nnue/evaluate_nnue.h"
 
 using namespace std;
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -19,6 +19,8 @@
 #ifndef UCI_H_INCLUDED
 #define UCI_H_INCLUDED
 
+#include <cstddef>
+#include <iosfwd>
 #include <map>
 #include <string>
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -18,16 +18,23 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cctype>
+#include <cstddef>
+#include <iosfwd>
+#include <istream>
+#include <map>
 #include <ostream>
 #include <sstream>
+#include <string>
 
 #include "evaluate.h"
 #include "misc.h"
 #include "search.h"
+#include "syzygy/tbprobe.h"
 #include "thread.h"
 #include "tt.h"
+#include "types.h"
 #include "uci.h"
-#include "syzygy/tbprobe.h"
 
 using std::string;
 


### PR DESCRIPTION
This applies the suggestions from include-what-you-use without the includes for namespace std. Feel free to combine with your commit.