### PR TITLE
Fix

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1148,7 +1148,7 @@ moves_loop:  // When in check, search starts here
         {
             // In general we want to cap the LMR depth search at newDepth, but when
             // reduction is negative, we allow this move a limited search extension
-            // beyond the first move depth. This may lead to hidden multiple extensions.
+            // beyond the first move depth. 
             // To prevent problems when the max value is less than the min value,
             // std::clamp has been replaced by a more robust implementation.
             Depth d = std::max(1, std::min(newDepth - r, newDepth + 1));


### PR DESCRIPTION
All extensions are now move==ttMove, so we have no hidden extensions in LMR